### PR TITLE
Implement feature throttle (rate limitation)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 ruby "2.3.3"
 
@@ -6,10 +6,10 @@ ruby "2.3.3"
 gem "rails", "4.2.8"
 gem "pg"
 gem "rails-api"
-gem "rails_api_format", git: "http://github.com/fs/rails-api-format.git"
+gem "rails_api_format", git: "https://github.com/fs/rails-api-format.git"
 
 # all other gems
-gem "active_model_serializers"
+gem "active_model_serializers", git: "https://github.com/rails-api/active_model_serializers.git"
 gem "decent_exposure"
 gem "devise"
 gem "dotenv-rails"
@@ -40,7 +40,7 @@ group :development, :test do
 
   gem "rails_best_practices"
   gem "brakeman"
-  # gem "rubocop"
+  gem "rubocop"
   gem "bundler-audit"
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
 ruby "2.3.3"
 
@@ -6,10 +6,10 @@ ruby "2.3.3"
 gem "rails", "4.2.8"
 gem "pg"
 gem "rails-api"
-gem "rails_api_format", git: "https://github.com/fs/rails-api-format.git"
+gem "rails_api_format", git: "http://github.com/fs/rails-api-format.git"
 
 # all other gems
-gem "active_model_serializers", git: "https://github.com/rails-api/active_model_serializers.git"
+gem "active_model_serializers"
 gem "decent_exposure"
 gem "devise"
 gem "dotenv-rails"
@@ -40,7 +40,7 @@ group :development, :test do
 
   gem "rails_best_practices"
   gem "brakeman"
-  gem "rubocop"
+  # gem "rubocop"
   gem "bundler-audit"
 end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,24 +2,30 @@ class ApplicationController < ActionController::API
   include ActionController::ImplicitRender
   acts_as_token_authentication_handler_for User
   respond_to :json
-  
+
   def throttle(endpoint_name: :default)
-  	throttle_info = Rails.application.config_for(:throttle)
-  	throttle_time_window = throttle_info[:throttle_time_window]
-    throttle_max_requests = throttle_info[:throttle_max_requests]  
-    key = "user:#{current_user.id}_request_#{endpoint_name}"
-  	begin
-	  	count = REDIS.get(key)
-	    unless count
+
+    throttle_info = Rails.application.config_for(:throttle)
+  	throttle_time_window = throttle_info["#{endpoint_name}"]["throttle_time_window"]
+    throttle_max_requests = throttle_info["#{endpoint_name}"]["throttle_max_requests"]
+
+    if current_user.present?
+      key = "user:#{current_user.id}_request_#{endpoint_name}"
+    else
+      key = "user:#{request.remote_ip}_request_#{endpoint_name}"
+    end
+    begin
+      count = REDIS.get(key)
+	    if count.nil?
 	      REDIS.set(key, 0)
 	      REDIS.expire(key, throttle_time_window)
 	      return true
 	    end
-	    if count.to_i >= throttle_max_requests
+      if count.to_i >= throttle_max_requests
 	      render :status => 429, :json => {:message => "You have fired too many requests. Please wait for some time."}
 	      return
 	    end
-	    REDIS.incr(key)
+      REDIS.incr(key)
 	    true
 	  rescue => error
 	  	puts error.inspect

--- a/app/mailers/user_notifier.rb
+++ b/app/mailers/user_notifier.rb
@@ -3,8 +3,6 @@ class UserNotifier < ActionMailer::Base
 
   ### send email notification when redis server down
   def send_redis_down_email(email)
-    @user = user
-    mail( :to => @user.email, :subject => )
     mail(:to => email, :subject => "[#{Rails.env}]Redis server down") do |format|
 		  format.text do
 		    render :text => "Redis server is down, please check it !"

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,7 +27,7 @@ module RailsBaseApi
     config.noreply = "noreply@fs-rails-base-api.heroku.com"
 
     # Admin email
-    config.admin_email = admin@baseapi.com
+    config.admin_email = "admin@baseapi.com"
 
     # Default host for action mailer, initializers/mailer.rb
     config.host = "localhost:5000"

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -262,4 +262,5 @@ Devise.setup do |config|
   # When using OmniAuth, Devise cannot automatically set OmniAuth path,
   # so you need to do it manually. For the users scope, it would be:
   # config.omniauth_path_prefix = '/my_engine/users/auth'
+  config.secret_key = 'a78d3ec54dbbfe835182a40fc965d9279e19ad26e77b79f9563b5f32c757a06047a673d911b09f00cf1105eda66dfede77d2d26c6ca5132d29c7f4f550e67f75'
 end

--- a/config/redis.yml
+++ b/config/redis.yml
@@ -1,2 +1,6 @@
-host: localhost
-port: 6379
+development:
+  host: localhost
+  port: 6379
+production:
+  host: localhost
+  port: 6379

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -1,6 +1,6 @@
 default: &default
-  secret_key_base: <%= ENV['SECRET_KEY_BASE'] %>
-
+  # secret_key_base: <%= ENV['SECRET_KEY_BASE'] %>
+  secret_key_base: "dfjueu9324hdsifHJFJkdfjdkfi394349dKIJFJIFJIFJIDFJI94w9034593450KKGJIDGJIIJEWORIJEITJIOERTERGIDIOJGIOET2309902390434IRIJERGIJ"
 development:
   <<: *default
 

--- a/config/throttle.yml
+++ b/config/throttle.yml
@@ -1,11 +1,26 @@
-creat_post:
-  throttle_time_window: 60 
-  throttle_max_requests: 2 
+development:
+  create_post:
+    throttle_time_window: 60
+    throttle_max_requests: 2
 
-get_posts:
-  throttle_time_window: 15  
-  throttle_max_requests: 60  
+  get_posts:
+    throttle_time_window: 15
+    throttle_max_requests: 60
 
-default:
-  throttle_time_window: 15
-  throttle_max_requests: 15
+  default:
+    throttle_time_window: 15
+    throttle_max_requests: 15
+
+
+production:
+  create_post:
+    throttle_time_window: 60
+    throttle_max_requests: 2
+
+  get_posts:
+    throttle_time_window: 15
+    throttle_max_requests: 60
+
+  default:
+    throttle_time_window: 15
+    throttle_max_requests: 15


### PR DESCRIPTION
### My Solution

1 - We need a place to store each user with the number of requests endpoint . We need to increment this count for each request and reset the count to zero after a time period.

2 - I use redis for this data store. Redis stores key value pairs and allows expiry time to be specified for each entry. Redis also comes with an INCR 1 command that ensures that increment operations are atomic.

3 - I will add a new initializer named throttle.rb which configures our Redis client.

```
# config/initializers/redis.rb
require "redis"
redis_conf  = Rails.application.config_for(:redis)
REDIS = Redis.new(:host => redis_conf["host"], :port => redis_conf["port"])
```

```
# config/redis.yml
development:
  host: localhost
  port: 6379
production:
  host: localhost
  port: 6379
```

4 - I implement method throttle within ApplicationController

```
def throttle(endpoint_name: :default)
    throttle_info = Rails.application.config_for(:throttle)
  	throttle_time_window = throttle_info["#{endpoint_name}"]["throttle_time_window"]
    throttle_max_requests = throttle_info["#{endpoint_name}"]["throttle_max_requests"]

    if current_user.present?
      key = "user:#{current_user.id}_request_#{endpoint_name}"
    else
      key = "user:#{request.remote_ip}_request_#{endpoint_name}"
    end
    begin
       count = REDIS.get(key)
       if count.nil?
	    REDIS.set(key, 0)
	    REDIS.expire(key, throttle_time_window)
	    return true
       end
       if count.to_i >= throttle_max_requests
	    render :status => 429, :json => {:message => "You have fired too many requests. Please wait for some time."}
	    return
      end
      REDIS.incr(key)
      true
    rescue => error
      puts error.inspect
      ### send email or SMS notification to developer group
      UserNotifier.send_redis_down_email(Rails.application.config.admin_email)
    end
end
```

5 - Throttle config for every endpoint implemented in file config/throttle.yml
```
create_post:
   throttle_time_window: 60
   throttle_max_requests: 2
get_posts:
   throttle_time_window: 15
   throttle_max_requests: 60
default:
   throttle_time_window: 15
   throttle_max_requests: 15
```

6 - In every endpoints, i implemented callbacks for checking throtte, an example with Post controller:

```
/v1/posts_controller.rb

before_action only: [:create] do
   throttle(endpoint_name: :create_post)
end

before_action only: [:index, :show] do
   throttle(endpoint_name: :get_posts)
end
```

### Restrict

1 - We must install redis server support feature:
```
	On Ubuntu:
	$ wget http://redis.googlecode.com/files/redis-2.4.8.tar.gz
	$ tar -zxvf redis-2.4.8.tar.gz
	$ cd redis-2.4.8
	$ make
	$ make install
	$ make test

	On Mac:
	brew install redis

	Run Redis server:
	$ redis-server --daemonize yes

	Test Redis:
	redis-cli

```

2 - Must implement error handling when the redis server is down by catch exeption and send email notification to admin group. In the time redis server is down, throttle feature is stopped.

```
def send_redis_down_email(email)
    mail(:to => email, :subject => "[#{Rails.env}]Redis server down") do |format|
       format.text do
          render :text => "Redis server down, please check it !"
          end
       end
 end
```

3 - When i do testing reason have more time, i skipped validate user for check feature throttle.
Comment out the command: acts_as_token_authentication_handler_for User   in ApplicationController.

### Testing
1.Can  create maximum 2 posts within 60 minutes
 - Request information:   
![create_post](https://user-images.githubusercontent.com/26106210/31069212-a13de3c2-a785-11e7-8294-406b4113df77.png)

 - Redis information: 
![create_post_redis](https://user-images.githubusercontent.com/26106210/31069228-b22f5e2c-a785-11e7-89df-a4fa541a390d.png)

2.Can send maximum 15 requests with 15 second
 - Request information:
   ![get_endpoint_defaut](https://user-images.githubusercontent.com/26106210/31069324-39354f12-a786-11e7-8d6a-1edd79f563da.png)

 - Redis information: 
![get_endpoint_defautl_redis](https://user-images.githubusercontent.com/26106210/31069334-4096a710-a786-11e7-87c9-a2cd966915a6.png)

### Improvement:

1 - I want to implement only one callback throttle in Application Controller, it supports checking for all endpoints. But i don't know how to detect every end point request(name and method type is GET, POST or UPDATE) in Application Controller. So i must use callback in every endpoint controller.

2 - If I have more time, i want to implement throttle config in a file.yaml not use redis.